### PR TITLE
[finosmeetings] Add `date_iso_format` attribute

### DIFF
--- a/perceval/backends/finos/finosmeetings.py
+++ b/perceval/backends/finos/finosmeetings.py
@@ -41,6 +41,8 @@ CSV_HEADER = 'email,name,org,githubid,program,activity,date'
 SKIP_HEADER = True
 ID_COLUMNS = 'email,name,date'
 DATE_COLUMN = 'date'
+TIMESTAMP = 'timestamp'
+DATE_ISO = 'date_iso_format'
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +111,8 @@ class FinosMeetings(Backend):
                 if column == DATE_COLUMN:
                     try:
                         dt = str_to_datetime(value)
-                        ret['timestamp'] = datetime_to_utc(dt).timestamp()
+                        ret[DATE_ISO] = datetime_to_utc(dt).isoformat()
+                        ret[TIMESTAMP] = datetime_to_utc(dt).timestamp()
                     except InvalidDateError:
                         logger.warning("Skipping entry due to wrong date format: '%s'", value)
                         nskipped += 1

--- a/tests/test_finosmeetings.py
+++ b/tests/test_finosmeetings.py
@@ -114,9 +114,12 @@ class TestFinosMeetingsBackend(unittest.TestCase):
         self.assertEqual(len(http_requests), 1)
 
         # Test metadata
-        expected = [('rob.underwood@finos.org', 'Rob Underwood', 'brooklynrob', 'Data Tech', 'Data Tech PMC', '2018-09-28'),
-                    ('tosha.ellison@finos.org', 'Tosha Ellison', '', 'Data Tech', 'Security Reference Data', '2018-12-11'),
-                    ('maoo@finos.org', 'Maurizio Pillitu', 'maoo', 'FDC3', 'FDC3 PMC', '2018-10-19')]
+        expected = [('rob.underwood@finos.org', 'Rob Underwood', 'brooklynrob',
+                     'Data Tech', 'Data Tech PMC', '2018-09-28', '2018-09-28T00:00:00+00:00'),
+                    ('tosha.ellison@finos.org', 'Tosha Ellison', '', 'Data Tech',
+                     'Security Reference Data', '2018-12-11', '2018-12-11T00:00:00+00:00'),
+                    ('maoo@finos.org', 'Maurizio Pillitu', 'maoo',
+                     'FDC3', 'FDC3 PMC', '2018-10-19', '2018-10-19T00:00:00+00:00')]
 
         for x in range(len(expected)):
             entry = entries[x]['data']
@@ -129,6 +132,7 @@ class TestFinosMeetingsBackend(unittest.TestCase):
             self.assertEqual(entry['program'], expected[x][3])
             self.assertEqual(entry['activity'], expected[x][4])
             self.assertEqual(entry['date'], expected[x][5])
+            self.assertEqual(entry['date_iso_format'], expected[x][6])
 
     @httpretty.activate
     def test_fetch_from_file(self):
@@ -141,9 +145,12 @@ class TestFinosMeetingsBackend(unittest.TestCase):
         self.assertEqual(len(entries), 3)
 
         # Test metadata
-        expected = [('rob.underwood@finos.org', 'Rob Underwood', 'brooklynrob', 'Data Tech', 'Data Tech PMC', '2018-09-28'),
-                    ('tosha.ellison@finos.org', 'Tosha Ellison', '', 'Data Tech', 'Security Reference Data', '2018-12-11'),
-                    ('maoo@finos.org', 'Maurizio Pillitu', 'maoo', 'FDC3', 'FDC3 PMC', '2018-10-19')]
+        expected = [('rob.underwood@finos.org', 'Rob Underwood', 'brooklynrob',
+                     'Data Tech', 'Data Tech PMC', '2018-09-28', '2018-09-28T00:00:00+00:00'),
+                    ('tosha.ellison@finos.org', 'Tosha Ellison', '', 'Data Tech',
+                     'Security Reference Data', '2018-12-11', '2018-12-11T00:00:00+00:00'),
+                    ('maoo@finos.org', 'Maurizio Pillitu', 'maoo',
+                     'FDC3', 'FDC3 PMC', '2018-10-19', '2018-10-19T00:00:00+00:00')]
 
         for x in range(len(expected)):
             entry = entries[x]['data']
@@ -156,6 +163,7 @@ class TestFinosMeetingsBackend(unittest.TestCase):
             self.assertEqual(entry['program'], expected[x][3])
             self.assertEqual(entry['activity'], expected[x][4])
             self.assertEqual(entry['date'], expected[x][5])
+            self.assertEqual(entry['date_iso_format'], expected[x][6])
 
     @httpretty.activate
     def test_fetch_empty(self):


### PR DESCRIPTION
This code includes the attribute `date_iso_format`, which contains the iso format representation of the field `date`. This change is needed to standardize `date` values of different formats (e.g., 2019, 2019-1-1, 2019-01-01).