### PR TITLE
[doc] Fix typo in README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ pip3 install -e .
 In case you are a developer, you should execute the following commands to install Perceval in your working directory (option `-e`) and the packages of requirements_tests.txt.
 ```
 $ pip3 install -r requirements.txt
-$ pip3 install -r requirements_test.txt
+$ pip3 install -r requirements_tests.txt
 $ pip3 install -e .
 ```
 


### PR DESCRIPTION
This code fixes a typo in the command to install the requirements for tests.