### PR TITLE
Renaming fields

### DIFF
--- a/perceval/backends/finos/finosmeetings.py
+++ b/perceval/backends/finos/finosmeetings.py
@@ -61,7 +61,7 @@ class FinosMeetings(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.1.0'
+    version = '0.2.0'
 
     CATEGORIES = [CATEGORY_ENTRY]
 

--- a/perceval/backends/finos/finosmeetings.py
+++ b/perceval/backends/finos/finosmeetings.py
@@ -37,9 +37,9 @@ from ...client import HttpClient
 
 CATEGORY_ENTRY = "finos-meeting-entry"
 SEPARATOR = ','
-CSV_HEADER = 'email,name,org,githubid,program,activity,date'
+CSV_HEADER = 'email,name,org,githubid,cm_program,cm_title,date'
 SKIP_HEADER = True
-ID_COLUMNS = 'email,name,date,program,activity'
+ID_COLUMNS = 'email,name,date,cm_program,cm_title'
 DATE_COLUMN = 'date'
 TIMESTAMP = 'timestamp'
 DATE_ISO = 'date_iso_format'

--- a/tests/data/finosmeetings/finosmeetings_entries.csv
+++ b/tests/data/finosmeetings/finosmeetings_entries.csv
@@ -1,4 +1,4 @@
-email, name, organization, github id, program, activity, date
+email, name, organization, github id, cm_program, cm_title, date
 rob.underwood@finos.org, Rob Underwood, FINOS, brooklynrob, Data Tech, Data Tech PMC, 2018-09-28
 tosha.ellison@finos.org, Tosha Ellison, FINOS, , Data Tech, Security Reference Data, 2018-12-11
 maoo@finos.org, Maurizio Pillitu, FINOS, maoo, FDC3, FDC3 PMC, 2018-10-19

--- a/tests/test_finosmeetings.py
+++ b/tests/test_finosmeetings.py
@@ -129,8 +129,8 @@ class TestFinosMeetingsBackend(unittest.TestCase):
             self.assertEqual(entry['name'], expected[x][1])
             self.assertEqual(entry['org'], 'FINOS')
             self.assertEqual(entry['githubid'], expected[x][2])
-            self.assertEqual(entry['program'], expected[x][3])
-            self.assertEqual(entry['activity'], expected[x][4])
+            self.assertEqual(entry['cm_program'], expected[x][3])
+            self.assertEqual(entry['cm_title'], expected[x][4])
             self.assertEqual(entry['date'], expected[x][5])
             self.assertEqual(entry['date_iso_format'], expected[x][6])
 
@@ -160,8 +160,8 @@ class TestFinosMeetingsBackend(unittest.TestCase):
             self.assertEqual(entry['name'], expected[x][1])
             self.assertEqual(entry['org'], 'FINOS')
             self.assertEqual(entry['githubid'], expected[x][2])
-            self.assertEqual(entry['program'], expected[x][3])
-            self.assertEqual(entry['activity'], expected[x][4])
+            self.assertEqual(entry['cm_program'], expected[x][3])
+            self.assertEqual(entry['cm_title'], expected[x][4])
             self.assertEqual(entry['date'], expected[x][5])
             self.assertEqual(entry['date_iso_format'], expected[x][6])
 


### PR DESCRIPTION
`activity` becomes `cm_title`
`program` becomes `cm_program`

This way field names match and no index pattern is used on Kibana to match fields.