### PR TITLE
[finosmeetings] Update argument parser to display categories in help message

### DIFF
--- a/perceval/backends/finos/finosmeetings.py
+++ b/perceval/backends/finos/finosmeetings.py
@@ -226,11 +226,11 @@ class FinosMeetingsCommand(BackendCommand):
 
     BACKEND = FinosMeetings
 
-    @staticmethod
-    def setup_cmd_parser():
+    @classmethod
+    def setup_cmd_parser(cls):
         """Returns the FinosMeetings argument parser."""
 
-        parser = BackendCommandArgumentParser()
+        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES)
 
         # Required arguments
         parser.parser.add_argument('uri',

--- a/tests/test_finosmeetings.py
+++ b/tests/test_finosmeetings.py
@@ -197,6 +197,7 @@ class TestFinosMeetingsCommand(unittest.TestCase):
 
         parser = FinosMeetingsCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._categories, FinosMeetings.CATEGORIES)
 
         args = [MEETINGS_URL]
 


### PR DESCRIPTION
With the recent changes in Perceval, the argument parser requires the list of categories to show them when '--help' parameter is active.