### PR TITLE
[finosmeetings] Add search fields

### DIFF
--- a/perceval/backends/finos/finosmeetings.py
+++ b/perceval/backends/finos/finosmeetings.py
@@ -60,7 +60,7 @@ class FinosMeetings(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.3.0'
+    version = '0.4.0'
 
     CATEGORIES = [CATEGORY_ENTRY]
 

--- a/tests/test_finosmeetings.py
+++ b/tests/test_finosmeetings.py
@@ -134,6 +134,19 @@ class TestFinosMeetingsBackend(unittest.TestCase):
             self.assertEqual(entry['date_iso_format'], expected[x][7])
 
     @httpretty.activate
+    def test_search_terms(self):
+        """Test whether the search_fields is properly set"""
+
+        configure_http_server()
+
+        finosmeetings = FinosMeetings(MEETINGS_URL)
+
+        entries = [entry for entry in finosmeetings.fetch()]
+
+        for e in entries:
+            self.assertEqual(finosmeetings.metadata_id(e['data']), e['search_fields']['item_id'])
+
+    @httpretty.activate
     def test_fetch_from_file(self):
         """Test whether a list of entries is returned from a file definition"""
 


### PR DESCRIPTION
This code updates the version of the Finosmeetings backend, which now includes the default search
field (`item_id`).

Tests have been added accordingly.
The backend version is set to 0.4.0.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>