### PR TITLE
[backend] Change signature BackendCommandArgumentParser

### DIFF
--- a/perceval/backends/finos/finosmeetings.py
+++ b/perceval/backends/finos/finosmeetings.py
@@ -229,7 +229,7 @@ class FinosMeetingsCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the FinosMeetings argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES)
+        parser = BackendCommandArgumentParser(cls.BACKEND)
 
         # Required arguments
         parser.parser.add_argument('uri',

--- a/tests/test_finosmeetings.py
+++ b/tests/test_finosmeetings.py
@@ -208,7 +208,7 @@ class TestFinosMeetingsCommand(unittest.TestCase):
 
         parser = FinosMeetingsCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, FinosMeetings.CATEGORIES)
+        self.assertEqual(parser._backend, FinosMeetings)
 
         args = [MEETINGS_URL]
 


### PR DESCRIPTION
This code changes the signature of the class `BackendCommandArgumentParser`, which now accepts as first parameter the backend object instead its categories. This change is needed to simplify accessing other backend attributes, beyond the categories.

Finosmeeting backend and corresponding tests have been updated.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>